### PR TITLE
feat/nvmevirt

### DIFF
--- a/docs/NVMEVIRT_SETUP.md
+++ b/docs/NVMEVIRT_SETUP.md
@@ -1,0 +1,540 @@
+# NVMeVirt Setup Guide
+
+This guide explains how to set up and use nvmevirt for benchmarking the NVMe-KV Engine on Linux systems.
+
+## Table of Contents
+
+- [Overview](#overview)
+- [System Requirements](#system-requirements)
+- [Prerequisites](#prerequisites)
+- [Quick Start](#quick-start)
+- [Manual Setup](#manual-setup)
+- [Running Benchmarks](#running-benchmarks)
+- [Troubleshooting](#troubleshooting)
+- [Cleanup](#cleanup)
+
+## Overview
+
+**nvmevirt** is a kernel-level NVMe emulator developed by Seoul National University's Computer Systems Laboratory (SNU-CSL). It provides more accurate performance characteristics compared to userspace emulators like openMPDK's emulator.
+
+**Use cases:**
+- Development environment: Use openMPDK emulator in Docker
+- Benchmarking/Testing: Use nvmevirt for realistic performance testing
+
+**GitHub Repository:** https://github.com/snu-csl/nvmevirt
+
+## System Requirements
+
+### Operating System
+- **Linux only** (nvmevirt is a Linux kernel module)
+- Kernel version **5.15 or higher**
+- Tested on: Arch Linux, Ubuntu, Debian, Fedora, CentOS
+
+### Hardware
+- **Minimum 2 CPU cores** dedicated to nvmevirt
+- **64GB+ reserved physical memory** (configurable)
+- **x86_64 architecture**
+
+### Software Dependencies
+- Kernel headers matching your running kernel
+- Build tools: `gcc`, `make`, `cmake`
+- Git (for cloning nvmevirt repository)
+
+## Prerequisites
+
+### 1. Check Kernel Version
+
+```bash
+uname -r
+```
+
+Ensure version is **5.15.x or higher**. If not, upgrade your kernel.
+
+### 2. Install Kernel Headers
+
+The kernel headers **must exactly match** your running kernel version.
+
+#### Arch Linux
+```bash
+sudo pacman -S linux-headers
+```
+
+#### Ubuntu/Debian
+```bash
+sudo apt-get install linux-headers-$(uname -r)
+```
+
+#### Fedora
+```bash
+sudo dnf install kernel-devel-$(uname -r)
+```
+
+#### CentOS/RHEL
+```bash
+sudo yum install kernel-devel-$(uname -r)
+```
+
+#### openSUSE
+```bash
+sudo zypper install kernel-default-devel
+```
+
+Verify installation:
+```bash
+ls -d /lib/modules/$(uname -r)/build
+```
+
+### 3. Reserve Physical Memory (REQUIRED)
+
+nvmevirt requires reserved physical memory that won't be used by the system. This is configured via GRUB.
+
+#### Step 1: Edit GRUB Configuration
+
+```bash
+sudo nano /etc/default/grub
+```
+
+#### Step 2: Add Memory Reservation
+
+Modify the `GRUB_CMDLINE_LINUX` line to include `memmap`:
+
+```bash
+GRUB_CMDLINE_LINUX="memmap=64G\$128G"
+```
+
+**Format:** `memmap=SIZE$START`
+- `SIZE`: Amount of memory to reserve (e.g., `64G`)
+- `START`: Physical memory offset where reservation begins (e.g., `128G`)
+
+**Important:** Adjust based on your total RAM:
+- System with 256GB RAM: `memmap=64G$128G` (reserves 64GB starting at 128GB offset)
+- System with 128GB RAM: `memmap=32G$64G` (reserves 32GB starting at 64GB offset)
+- System with 64GB RAM: `memmap=16G$32G` (reserves 16GB starting at 32GB offset)
+
+#### Step 3: Update GRUB
+
+**Arch Linux:**
+```bash
+sudo grub-mkconfig -o /boot/grub/grub.cfg
+```
+
+**Ubuntu/Debian:**
+```bash
+sudo update-grub
+```
+
+**Fedora/CentOS/RHEL:**
+```bash
+sudo grub2-mkconfig -o /boot/grub2/grub.cfg
+```
+
+#### Step 4: Reboot
+
+```bash
+sudo reboot
+```
+
+#### Step 5: Verify Memory Reservation
+
+After reboot, verify the reservation:
+
+```bash
+cat /proc/cmdline | grep memmap
+```
+
+You should see: `memmap=64G$128G` (or your configured values)
+
+## Quick Start
+
+### Automated Setup
+
+Use the provided script to set up nvmevirt and build the project automatically:
+
+```bash
+sudo ./scripts/build-nvmevirt.sh
+```
+
+This script will:
+1. Check all prerequisites
+2. Clone nvmevirt repository
+3. Configure nvmevirt for KV mode
+4. Build the kernel module
+5. Load the module
+6. Build the KV engine with kernel driver support
+7. Run benchmarks
+
+**Skip to [Running Benchmarks](#running-benchmarks) if the script succeeds.**
+
+## Manual Setup
+
+If you prefer manual setup or the automated script fails:
+
+### 1. Clone nvmevirt Repository
+
+```bash
+cd /path/to/nvme-kv-engine
+git clone https://github.com/snu-csl/nvmevirt.git lib/nvmevirt
+```
+
+### 2. Configure for KV Mode
+
+nvmevirt supports multiple modes (NVM, SSD, ZNS, KV). We need KV mode.
+
+```bash
+cd lib/nvmevirt
+```
+
+Edit the `Kbuild` file:
+
+```bash
+nano Kbuild
+```
+
+Disable all modes except KV:
+
+```makefile
+# CONFIG_NVMEVIRT_NVM := y
+# CONFIG_NVMEVIRT_SSD := y
+# CONFIG_NVMEVIRT_ZNS := y
+CONFIG_NVMEVIRT_KV := y
+```
+
+### 3. Build the Kernel Module
+
+```bash
+make clean
+make
+```
+
+This creates `nvmev.ko` (the kernel module).
+
+### 4. Load the Kernel Module
+
+**Check if already loaded:**
+```bash
+lsmod | grep nvmev
+```
+
+**Unload if already loaded:**
+```bash
+sudo rmmod nvmev
+```
+
+**Load the module:**
+```bash
+sudo insmod ./nvmev.ko \
+    memmap_start="128G" \
+    memmap_size="64G" \
+    cpus="0,1"
+```
+
+**Parameters:**
+- `memmap_start`: Must match GRUB configuration
+- `memmap_size`: Must match GRUB configuration
+- `cpus`: CPU cores to dedicate (comma-separated, e.g., "0,1,2,3")
+
+**Verify device creation:**
+```bash
+ls -l /dev/nvme0n1
+```
+
+You should see:
+```
+brw-rw---- 1 root disk 259, 0 Nov 23 20:28 /dev/nvme0n1
+```
+
+**Check kernel logs:**
+```bash
+dmesg | tail -50
+```
+
+Look for nvmevirt initialization messages.
+
+### 5. Build KV Engine for nvmevirt
+
+Use the provided build script:
+
+```bash
+./scripts/build-for-nvmevirt.sh --clean
+```
+
+Or manually:
+
+```bash
+# Build KVSSD with kernel driver support
+cd lib/KVSSD/PDK/core
+mkdir -p build && cd build
+cmake -DWITH_KDD=ON ..
+make kvapi
+
+# Build main project
+cd /path/to/nvme-kv-engine
+mkdir -p build && cd build
+cmake -DWITH_EMU=OFF -DWITH_KDD=ON ..
+make
+```
+
+## Running Benchmarks
+
+### Throughput Benchmark
+
+```bash
+cd build/benchmarks
+sudo ./bench_throughput /dev/nvme0n1 100000
+```
+
+**Parameters:**
+- First argument: Device path (`/dev/nvme0n1`)
+- Second argument: Number of operations (default: 100,000)
+
+**Example output:**
+```
+=== NVMe-KV Engine Throughput Benchmark ===
+Device: /dev/nvme0n1
+Number of operations: 100000
+Key size: 16 bytes
+Value size: 4096 bytes
+
+Running WRITE benchmark...
+WRITE: 100000 ops in 2.345 seconds
+  Throughput: 42,643 ops/sec
+  Latency: 23.45 μs/op
+  Bandwidth: 166.18 MB/s
+
+Running READ benchmark...
+READ: 100000 ops in 1.876 seconds
+  Throughput: 53,305 ops/sec
+  Latency: 18.76 μs/op
+  Bandwidth: 207.83 MB/s
+```
+
+### Running Examples
+
+```bash
+cd build/examples
+
+# Simple store/retrieve example
+sudo ./simple_store /dev/nvme0n1
+
+# Cache workload example
+sudo ./simple_cache /dev/nvme0n1
+
+# Async operations example
+sudo ./async_example /dev/nvme0n1
+```
+
+## Troubleshooting
+
+### Module Load Fails
+
+**Error:** `insmod: ERROR: could not insert module`
+
+**Solutions:**
+
+1. **Check memory reservation:**
+   ```bash
+   cat /proc/cmdline | grep memmap
+   ```
+   If not present, revisit [Prerequisites - Step 3](#3-reserve-physical-memory-required).
+
+2. **Check kernel logs:**
+   ```bash
+   dmesg | tail -50
+   ```
+   Look for specific error messages.
+
+3. **IOMMU conflict:**
+   Add `intremap=off` to GRUB command line:
+   ```bash
+   GRUB_CMDLINE_LINUX="memmap=64G$128G intremap=off"
+   ```
+   Update GRUB and reboot.
+
+4. **CPU cores unavailable:**
+   Try different CPU cores:
+   ```bash
+   sudo insmod ./nvmev.ko memmap_start="128G" memmap_size="64G" cpus="2,3"
+   ```
+
+### Device Not Created
+
+**Error:** `/dev/nvme0n1` doesn't exist after loading module
+
+**Solutions:**
+
+1. Wait a few seconds after loading:
+   ```bash
+   sudo insmod ./nvmev.ko memmap_start="128G" memmap_size="64G" cpus="0,1"
+   sleep 3
+   ls -l /dev/nvme0n1
+   ```
+
+2. Check `dmesg` for errors:
+   ```bash
+   dmesg | grep -i nvme
+   ```
+
+3. Verify module is loaded:
+   ```bash
+   lsmod | grep nvmev
+   ```
+
+### Permission Denied
+
+**Error:** `Permission denied` when running benchmarks
+
+**Solution:**
+The device requires root access. Always use `sudo`:
+```bash
+sudo ./bench_throughput /dev/nvme0n1 100000
+```
+
+### Build Errors
+
+**Error:** Compilation fails with missing headers
+
+**Solutions:**
+
+1. **Kernel headers mismatch:**
+   ```bash
+   # Verify exact match
+   uname -r
+   ls /lib/modules/$(uname -r)/build
+   ```
+
+2. **Reinstall kernel headers:**
+   ```bash
+   # Arch
+   sudo pacman -S linux-headers
+
+   # Ubuntu/Debian
+   sudo apt-get install --reinstall linux-headers-$(uname -r)
+   ```
+
+3. **Update CMake:**
+   Ensure CMake version ≥ 3.10:
+   ```bash
+   cmake --version
+   ```
+
+### Performance Issues
+
+**Symptoms:** Benchmarks show unexpectedly low performance
+
+**Solutions:**
+
+1. **Increase CPU cores:**
+   ```bash
+   sudo rmmod nvmev
+   sudo insmod ./nvmev.ko memmap_start="128G" memmap_size="64G" cpus="0,1,2,3"
+   ```
+
+2. **Increase memory reservation:**
+   Edit GRUB to reserve more memory, update GRUB, and reboot.
+
+3. **Check system load:**
+   ```bash
+   htop
+   ```
+   Ensure no other processes are consuming resources.
+
+## Cleanup
+
+### Unload nvmevirt Module
+
+```bash
+sudo rmmod nvmev
+```
+
+### Verify Unloaded
+
+```bash
+lsmod | grep nvmev
+ls /dev/nvme0n1  # Should return "No such file or directory"
+```
+
+### Remove Memory Reservation (Optional)
+
+If you want to reclaim the reserved memory:
+
+1. Edit `/etc/default/grub`
+2. Remove `memmap=64G$128G` from `GRUB_CMDLINE_LINUX`
+3. Update GRUB
+4. Reboot
+
+## Environment Variables
+
+You can customize nvmevirt setup using environment variables:
+
+```bash
+export NVMEVIRT_MEMMAP_START="128G"   # Memory start offset
+export NVMEVIRT_MEMMAP_SIZE="64G"     # Memory size to reserve
+export NVMEVIRT_CPUS="0,1,2,3"        # CPU cores to use
+export NVMEVIRT_DIR="./lib/nvmevirt"  # nvmevirt directory
+
+sudo ./scripts/build-nvmevirt.sh
+```
+
+## Switching Between Emulator and nvmevirt
+
+### For Development (openMPDK Emulator in Docker)
+
+```bash
+# Build for emulator
+cd build
+cmake -DWITH_EMU=ON ..
+make
+
+# Run in Docker
+./scripts/run_examples.sh
+```
+
+Device: `/dev/kvemul`
+
+### For Benchmarking (nvmevirt)
+
+```bash
+# Build for nvmevirt
+./scripts/build-for-nvmevirt.sh --clean
+
+# Load nvmevirt module (if not loaded)
+cd lib/nvmevirt
+sudo insmod ./nvmev.ko memmap_start="128G" memmap_size="64G" cpus="0,1"
+
+# Run benchmarks
+cd ../../build/benchmarks
+sudo ./bench_throughput /dev/nvme0n1 100000
+```
+
+Device: `/dev/nvme0n1`
+
+## Additional Resources
+
+- **nvmevirt GitHub:** https://github.com/snu-csl/nvmevirt
+- **nvmevirt Paper:** [SNU-CSL Research Publications](https://csl.snu.ac.kr/)
+- **Linux NVMe Documentation:** https://www.kernel.org/doc/html/latest/nvme/
+- **KVSSD API Documentation:** `lib/KVSSD/PDK/core/include/`
+
+## Summary
+
+| Step | Command |
+|------|---------|
+| 1. Install kernel headers | `sudo pacman -S linux-headers` (or distro equivalent) |
+| 2. Reserve memory in GRUB | Add `memmap=64G$128G` to `/etc/default/grub` |
+| 3. Update GRUB | `sudo grub-mkconfig -o /boot/grub/grub.cfg` |
+| 4. Reboot | `sudo reboot` |
+| 5. Run setup script | `sudo ./scripts/build-nvmevirt.sh` |
+| 6. Run benchmarks | `sudo ./build/benchmarks/bench_throughput /dev/nvme0n1 100000` |
+
+For quick benchmarking on an already-configured system, just:
+
+```bash
+# Load module (if not loaded)
+cd lib/nvmevirt && sudo insmod ./nvmev.ko memmap_start="128G" memmap_size="64G" cpus="0,1"
+
+# Build project
+cd ../.. && ./scripts/build-for-nvmevirt.sh
+
+# Run benchmarks
+cd build/benchmarks && sudo ./bench_throughput /dev/nvme0n1 100000
+```

--- a/lib/KVSSD/PDK/core/CMakeLists.txt
+++ b/lib/KVSSD/PDK/core/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.9)
+cmake_minimum_required(VERSION 3.5)
 project (libkvapi C CXX)
 
 option(WITH_EMU "Enable Emulator support" OFF)

--- a/lib/KVSSD/PDK/core/src/device_abstract_layer/kernel_driver_adapter/kadi.h
+++ b/lib/KVSSD/PDK/core/src/device_abstract_layer/kernel_driver_adapter/kadi.h
@@ -6,6 +6,7 @@
 #define CEPH_KADI_H
 
 #include <pthread.h>
+#include <string>
 #include <map>
 #include <vector>
 #include <mutex>

--- a/scripts/build-for-nvmevirt.sh
+++ b/scripts/build-for-nvmevirt.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+#
+# build-for-nvmevirt.sh - Build the KV engine for nvmevirt benchmarking
+#
+# This script builds the project with kernel driver support for use with nvmevirt.
+# Run this after nvmevirt is set up, or use build-nvmevirt.sh for full setup.
+#
+# Usage:
+#   ./scripts/build-for-nvmevirt.sh [--clean]
+#
+# Options:
+#   --clean    Clean build directories before building
+#
+
+set -euo pipefail
+
+# Color codes for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+SCRIPT_DIR="$(dirname "$(realpath "$0")")"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+
+CLEAN_BUILD=false
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --clean)
+            CLEAN_BUILD=true
+            shift
+            ;;
+        *)
+            echo "Unknown option: $1"
+            echo "Usage: $0 [--clean]"
+            exit 1
+            ;;
+    esac
+done
+
+echo -e "${BLUE}=== Building NVMe-KV Engine for nvmevirt ===${NC}\n"
+
+# ============================================================================
+# Helper Functions
+# ============================================================================
+
+print_error() {
+    echo -e "${RED}ERROR: $1${NC}" >&2
+}
+
+print_warning() {
+    echo -e "${YELLOW}WARNING: $1${NC}"
+}
+
+print_success() {
+    echo -e "${GREEN}✓ $1${NC}"
+}
+
+print_info() {
+    echo -e "${BLUE}ℹ $1${NC}"
+}
+
+# ============================================================================
+# Build Functions
+# ============================================================================
+
+clean_builds() {
+    print_info "Cleaning build directories..."
+
+    # Clean KVSSD build
+    if [[ -d "$PROJECT_DIR/lib/KVSSD/PDK/core/build" ]]; then
+        rm -rf "$PROJECT_DIR/lib/KVSSD/PDK/core/build"
+        print_success "Cleaned KVSSD build directory"
+    fi
+
+    # Clean main build
+    if [[ -d "$PROJECT_DIR/build" ]]; then
+        rm -rf "$PROJECT_DIR/build"
+        print_success "Cleaned main build directory"
+    fi
+}
+
+build_kvssd() {
+    print_info "Building KVSSD with kernel driver support..."
+
+    cd "$PROJECT_DIR/lib/KVSSD/PDK/core"
+    mkdir -p build && cd build
+
+    cmake -DWITH_KDD=ON ..
+    make kvapi
+
+    print_success "KVSSD built with kernel driver support"
+}
+
+build_main_project() {
+    print_info "Building main project..."
+
+    cd "$PROJECT_DIR"
+    mkdir -p build && cd build
+
+    cmake -DWITH_EMU=OFF -DWITH_KDD=ON ..
+    make
+
+    print_success "KV engine built successfully"
+}
+
+verify_binaries() {
+    print_info "Verifying build artifacts..."
+
+    local all_good=true
+
+    # Check benchmarks
+    if [[ -x "$PROJECT_DIR/build/benchmarks/bench_throughput" ]]; then
+        print_success "Benchmark binary: bench_throughput"
+    else
+        print_error "Benchmark binary not found: bench_throughput"
+        all_good=false
+    fi
+
+    # Check examples
+    for example in simple_store simple_cache async_example; do
+        if [[ -x "$PROJECT_DIR/build/examples/$example" ]]; then
+            print_success "Example binary: $example"
+        else
+            print_warning "Example binary not found: $example"
+        fi
+    done
+
+    # Check main library
+    if [[ -f "$PROJECT_DIR/build/libnvme_kv_engine.so" ]]; then
+        print_success "Main library: libnvme_kv_engine.so"
+    else
+        print_error "Main library not found: libnvme_kv_engine.so"
+        all_good=false
+    fi
+
+    if [[ "$all_good" == false ]]; then
+        print_error "Some binaries are missing. Build may have failed."
+        exit 1
+    fi
+}
+
+check_nvmevirt_device() {
+    if [[ -e /dev/nvme0n1 ]]; then
+        print_success "nvmevirt device found: /dev/nvme0n1"
+        ls -l /dev/nvme0n1
+        return 0
+    else
+        print_warning "nvmevirt device not found: /dev/nvme0n1"
+        echo ""
+        echo "The build is complete, but nvmevirt device is not available."
+        echo "To set up nvmevirt, run:"
+        echo "  sudo ./scripts/build-nvmevirt.sh"
+        echo ""
+        return 1
+    fi
+}
+
+# ============================================================================
+# Main Execution
+# ============================================================================
+
+main() {
+    print_info "Starting build process..."
+    echo ""
+
+    # Clean if requested
+    if [[ "$CLEAN_BUILD" == true ]]; then
+        clean_builds
+        echo ""
+    fi
+
+    # Build KVSSD
+    build_kvssd
+    echo ""
+
+    # Build main project
+    build_main_project
+    echo ""
+
+    # Verify binaries
+    verify_binaries
+    echo ""
+
+    # Check for nvmevirt device
+    check_nvmevirt_device
+    echo ""
+
+    print_success "Build complete!"
+    echo ""
+    print_info "To run benchmarks:"
+    echo "  cd $PROJECT_DIR/build/benchmarks"
+    echo "  sudo ./bench_throughput /dev/nvme0n1 100000"
+    echo ""
+    print_info "To run examples:"
+    echo "  cd $PROJECT_DIR/build/examples"
+    echo "  sudo ./simple_store /dev/nvme0n1"
+    echo "  sudo ./simple_cache /dev/nvme0n1"
+    echo "  sudo ./async_example /dev/nvme0n1"
+    echo ""
+}
+
+# Run main function
+main "$@"

--- a/scripts/build-nvmevirt.sh
+++ b/scripts/build-nvmevirt.sh
@@ -1,0 +1,381 @@
+#!/usr/bin/env bash
+#
+# build-nvmevirt.sh - Setup nvmevirt and build the KV engine for benchmarking
+#
+# This script sets up nvmevirt (a kernel-level NVMe emulator) for more accurate
+# benchmarking compared to the Docker + openMPDK emulation used for development.
+#
+# Requirements:
+# - Linux kernel v5.15.x or higher
+# - Kernel headers installed
+# - Physical memory reserved via GRUB (see instructions below)
+# - At least 2 CPU cores available for nvmevirt
+#
+# Usage:
+#   sudo ./scripts/build-nvmevirt.sh
+#
+
+set -euo pipefail
+
+# Color codes for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Configuration defaults
+MEMMAP_START="${NVMEVIRT_MEMMAP_START:-128G}"
+MEMMAP_SIZE="${NVMEVIRT_MEMMAP_SIZE:-64G}"
+NVMEVIRT_CPUS="${NVMEVIRT_CPUS:-0,1}"  # Default to cores 0,1
+NVMEVIRT_DIR="${NVMEVIRT_DIR:-./lib/nvmevirt}"
+
+SCRIPT_DIR="$(dirname "$(realpath "$0")")"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+
+echo -e "${BLUE}=== NVMe-KV Engine: nvmevirt Setup ===${NC}\n"
+
+# ============================================================================
+# Helper Functions
+# ============================================================================
+
+print_error() {
+    echo -e "${RED}ERROR: $1${NC}" >&2
+}
+
+print_warning() {
+    echo -e "${YELLOW}WARNING: $1${NC}"
+}
+
+print_success() {
+    echo -e "${GREEN}✓ $1${NC}"
+}
+
+print_info() {
+    echo -e "${BLUE}ℹ $1${NC}"
+}
+
+check_root() {
+    if [[ $EUID -ne 0 ]]; then
+        print_error "This script must be run as root (use sudo)"
+        exit 1
+    fi
+    print_success "Running as root"
+}
+
+check_linux() {
+    if [[ "$(uname -s)" != "Linux" ]]; then
+        print_error "This script requires Linux (nvmevirt is a Linux kernel module)"
+        exit 1
+    fi
+    print_success "Running on Linux"
+}
+
+check_kernel_version() {
+    local kernel_version
+    kernel_version=$(uname -r | cut -d. -f1,2)
+    local major minor
+    major=$(echo "$kernel_version" | cut -d. -f1)
+    minor=$(echo "$kernel_version" | cut -d. -f2)
+
+    if [[ $major -lt 5 ]] || { [[ $major -eq 5 ]] && [[ $minor -lt 15 ]]; }; then
+        print_error "Kernel version 5.15 or higher required (current: $(uname -r))"
+        exit 1
+    fi
+    print_success "Kernel version $(uname -r) is supported"
+}
+
+check_kernel_headers() {
+    local headers_dir="/lib/modules/$(uname -r)/build"
+    if [[ ! -d "$headers_dir" ]]; then
+        print_error "Kernel headers not found at $headers_dir"
+        echo ""
+
+        # Detect distribution and provide appropriate install command
+        if command -v pacman &> /dev/null; then
+            echo "Install with: sudo pacman -S linux-headers"
+        elif command -v apt-get &> /dev/null; then
+            echo "Install with: sudo apt-get install linux-headers-\$(uname -r)"
+        elif command -v dnf &> /dev/null; then
+            echo "Install with: sudo dnf install kernel-devel-\$(uname -r)"
+        elif command -v yum &> /dev/null; then
+            echo "Install with: sudo yum install kernel-devel-\$(uname -r)"
+        elif command -v zypper &> /dev/null; then
+            echo "Install with: sudo zypper install kernel-default-devel"
+        else
+            echo "Install kernel headers for your distribution"
+        fi
+        exit 1
+    fi
+    print_success "Kernel headers found"
+}
+
+check_memory_reservation() {
+    local cmdline
+    cmdline=$(cat /proc/cmdline)
+
+    if echo "$cmdline" | grep -q "memmap="; then
+        local memmap_param
+        memmap_param=$(echo "$cmdline" | grep -o 'memmap=[^ ]*' | head -1)
+        print_success "Memory reservation found: $memmap_param"
+        return 0
+    else
+        print_warning "No memory reservation found in kernel command line"
+        echo ""
+        echo "nvmevirt requires reserved physical memory. To set this up:"
+        echo ""
+        echo "1. Edit /etc/default/grub and add to GRUB_CMDLINE_LINUX:"
+        echo "   GRUB_CMDLINE_LINUX=\"memmap=${MEMMAP_SIZE}\\\$${MEMMAP_START}\""
+        echo ""
+        echo "   This reserves ${MEMMAP_SIZE} of memory starting at ${MEMMAP_START} offset"
+        echo "   (Adjust based on your system's total RAM)"
+        echo ""
+        echo "2. Update GRUB:"
+
+        # Detect distribution and provide appropriate GRUB update command
+        if command -v pacman &> /dev/null; then
+            echo "   sudo grub-mkconfig -o /boot/grub/grub.cfg"
+        elif command -v update-grub &> /dev/null; then
+            echo "   sudo update-grub"
+        else
+            echo "   sudo grub2-mkconfig -o /boot/grub2/grub.cfg"
+        fi
+
+        echo ""
+        echo "3. Reboot:"
+        echo "   sudo reboot"
+        echo ""
+        echo "4. Run this script again after reboot"
+        echo ""
+        read -p "Do you want to continue without memory reservation? (not recommended) [y/N] " -n 1 -r
+        echo
+        if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+            exit 1
+        fi
+        print_warning "Continuing without memory reservation (module loading may fail)"
+    fi
+}
+
+# ============================================================================
+# nvmevirt Setup
+# ============================================================================
+
+clone_nvmevirt() {
+    cd "$PROJECT_DIR"
+
+    if [[ -d "$NVMEVIRT_DIR" ]]; then
+        print_info "nvmevirt directory already exists at $NVMEVIRT_DIR"
+        return 0
+    fi
+
+    print_info "Cloning nvmevirt from GitHub..."
+    mkdir -p "$(dirname "$NVMEVIRT_DIR")"
+    git clone https://github.com/snu-csl/nvmevirt.git "$NVMEVIRT_DIR"
+    print_success "nvmevirt cloned"
+}
+
+configure_nvmevirt_kv() {
+    print_info "Configuring nvmevirt for KV mode..."
+
+    cd "$PROJECT_DIR/$NVMEVIRT_DIR"
+
+    # Backup original Kbuild if it exists
+    if [[ -f Kbuild ]] && [[ ! -f Kbuild.backup ]]; then
+        cp Kbuild Kbuild.backup
+    fi
+
+    # Configure for KV mode by modifying Kbuild
+    if [[ -f Kbuild ]]; then
+        sed -i 's/^CONFIG_NVMEVIRT_NVM := y/#CONFIG_NVMEVIRT_NVM := y/' Kbuild
+        sed -i 's/^CONFIG_NVMEVIRT_SSD := y/#CONFIG_NVMEVIRT_SSD := y/' Kbuild
+        sed -i 's/^CONFIG_NVMEVIRT_ZNS := y/#CONFIG_NVMEVIRT_ZNS := y/' Kbuild
+        sed -i 's/^#CONFIG_NVMEVIRT_KV := y/CONFIG_NVMEVIRT_KV := y/' Kbuild
+        sed -i 's/^CONFIG_NVMEVIRT_KV := y/#&/' Kbuild || true  # Comment out if already enabled
+        sed -i 's/^#CONFIG_NVMEVIRT_KV := y/CONFIG_NVMEVIRT_KV := y/' Kbuild  # Then enable
+        print_success "Kbuild configured for KV mode"
+    else
+        print_error "Kbuild file not found in $NVMEVIRT_DIR"
+        exit 1
+    fi
+}
+
+build_nvmevirt() {
+    print_info "Building nvmevirt kernel module..."
+
+    cd "$PROJECT_DIR/$NVMEVIRT_DIR"
+
+    make clean || true
+    make
+
+    if [[ ! -f nvmev.ko ]]; then
+        print_error "Failed to build nvmevirt (nvmev.ko not found)"
+        exit 1
+    fi
+
+    print_success "nvmevirt kernel module built successfully"
+}
+
+unload_existing_nvmevirt() {
+    if lsmod | grep -q "^nvmev "; then
+        print_info "Unloading existing nvmevirt module..."
+        rmmod nvmev || {
+            print_error "Failed to unload existing nvmevirt module"
+            print_info "You may need to manually unload it: sudo rmmod nvmev"
+            exit 1
+        }
+        print_success "Existing module unloaded"
+    fi
+}
+
+load_nvmevirt() {
+    print_info "Loading nvmevirt kernel module..."
+
+    cd "$PROJECT_DIR/$NVMEVIRT_DIR"
+
+    unload_existing_nvmevirt
+
+    # Parse memmap parameters from kernel command line if available
+    local cmdline
+    cmdline=$(cat /proc/cmdline)
+    if echo "$cmdline" | grep -q "memmap="; then
+        local memmap_full
+        memmap_full=$(echo "$cmdline" | grep -o 'memmap=[^ ]*' | head -1)
+        # Extract size and start from memmap=SIZE$START format
+        MEMMAP_SIZE=$(echo "$memmap_full" | sed 's/memmap=\([^$]*\)\$.*/\1/')
+        MEMMAP_START=$(echo "$memmap_full" | sed 's/memmap=[^$]*\$\(.*\)/\1/')
+    fi
+
+    print_info "Loading with parameters:"
+    print_info "  memmap_start=$MEMMAP_START"
+    print_info "  memmap_size=$MEMMAP_SIZE"
+    print_info "  cpus=$NVMEVIRT_CPUS"
+
+    insmod ./nvmev.ko \
+        memmap_start="$MEMMAP_START" \
+        memmap_size="$MEMMAP_SIZE" \
+        cpus="$NVMEVIRT_CPUS" || {
+        print_error "Failed to load nvmevirt module"
+        print_info "Check dmesg for details: dmesg | tail -50"
+        print_info ""
+        print_info "Common issues:"
+        print_info "  - Memory not reserved (check GRUB config)"
+        print_info "  - IOMMU conflict (try adding 'intremap=off' to GRUB)"
+        print_info "  - CPU cores not available (adjust NVMEVIRT_CPUS)"
+        exit 1
+    }
+
+    print_success "nvmevirt module loaded"
+
+    # Wait for device to appear
+    sleep 2
+
+    # Verify device is available
+    if [[ -e /dev/nvme0n1 ]]; then
+        print_success "NVMe device created: /dev/nvme0n1"
+        ls -l /dev/nvme0n1
+    else
+        print_error "NVMe device /dev/nvme0n1 not found after loading module"
+        print_info "Check dmesg: dmesg | tail -50"
+        exit 1
+    fi
+}
+
+# ============================================================================
+# Build KV Engine with Kernel Driver Support
+# ============================================================================
+
+build_kv_engine() {
+    print_info "Building KV engine with kernel driver support..."
+
+    cd "$PROJECT_DIR"
+
+    # Build KVSSD with kernel driver support
+    cd lib/KVSSD/PDK/core
+    mkdir -p build && cd build
+
+    print_info "Building KVSSD with WITH_KDD=ON..."
+    cmake -DWITH_KDD=ON ..
+    make kvapi
+
+    print_success "KVSSD built with kernel driver support"
+
+    # Build main project
+    cd "$PROJECT_DIR"
+    mkdir -p build && cd build
+
+    print_info "Building main project..."
+    cmake -DWITH_EMU=OFF ..
+    make
+
+    print_success "KV engine built successfully"
+}
+
+# ============================================================================
+# Run Benchmarks
+# ============================================================================
+
+run_benchmarks() {
+    print_info "Running benchmarks..."
+
+    cd "$PROJECT_DIR/build/benchmarks"
+
+    if [[ ! -x ./bench_throughput ]]; then
+        print_error "Benchmark binary not found or not executable"
+        exit 1
+    fi
+
+    print_info "Running throughput benchmark on /dev/nvme0n1..."
+    echo ""
+
+    ./bench_throughput /dev/nvme0n1 100000
+
+    echo ""
+    print_success "Benchmarks complete!"
+}
+
+# ============================================================================
+# Main Execution
+# ============================================================================
+
+main() {
+    print_info "Starting nvmevirt setup and benchmark process..."
+    echo ""
+
+    # Prerequisites checks
+    print_info "Checking prerequisites..."
+    check_root
+    check_linux
+    check_kernel_version
+    check_kernel_headers
+    check_memory_reservation
+    echo ""
+
+    # Setup nvmevirt
+    print_info "Setting up nvmevirt..."
+    clone_nvmevirt
+    configure_nvmevirt_kv
+    build_nvmevirt
+    load_nvmevirt
+    echo ""
+
+    # Build KV engine
+    build_kv_engine
+    echo ""
+
+    # Run benchmarks
+    run_benchmarks
+    echo ""
+
+    print_success "All done! nvmevirt is loaded and benchmarks have been run."
+    echo ""
+    print_info "To run benchmarks again:"
+    echo "  cd $PROJECT_DIR/build/benchmarks"
+    echo "  sudo ./bench_throughput /dev/nvme0n1 [num_ops]"
+    echo ""
+    print_info "To unload nvmevirt:"
+    echo "  sudo rmmod nvmev"
+    echo ""
+}
+
+# Run main function
+main "$@"


### PR DESCRIPTION
## Summary

This PR adds comprehensive support for **nvmevirt** (a kernel-level NVMe emulator) to enable accurate benchmarking of the NVMe-KV Engine on Linux systems.

### Key Changes

- **nvmevirt Integration**: Full setup automation with detailed documentation for using nvmevirt as a more accurate alternative to openMPDK emulator for benchmarking
- **Build Scripts**: Automated scripts for streamlined nvmevirt setup and project building with kernel driver support
- **Documentation**: Comprehensive 540-line setup guide covering prerequisites, installation, troubleshooting, and usage

### Technical Details

**New Files:**
- `docs/NVMEVIRT_SETUP.md` - Complete setup guide for nvmevirt
- `scripts/build-nvmevirt.sh` - Automated setup script for nvmevirt (clones, configures, builds, loads kernel module)
- `scripts/build-for-nvmevirt.sh` - Build script for KV engine with kernel driver support

**Modified Files:**
- `lib/KVSSD/PDK/core/CMakeLists.txt` - Update minimum CMake version to 3.5
- `lib/KVSSD/PDK/core/src/device_abstract_layer/kernel_driver_adapter/kadi.h` - Add missing `<string>` include

**Benefits:**
- **Dual Environment**: openMPDK emulator for development (Docker), nvmevirt for accurate benchmarking (native Linux)
- **Better Testing**: Kernel-level emulation provides more realistic performance characteristics than userspace emulation
- **Easy Setup**: Automated scripts with comprehensive error handling and prerequisite checks
- **Production-Ready**: Supports realistic workload testing before deployment

### Usage

**Quick Start:**
```bash
# Setup nvmevirt and build project
sudo ./scripts/build-nvmevirt.sh

# Or build project separately after nvmevirt setup
./scripts/build-for-nvmevirt.sh --clean
```

**Requirements:**
- Linux kernel 5.15+
- Kernel headers installed
- Physical memory reserved via GRUB (`memmap=64G$128G`)
- Root access for loading kernel modules

### Test Plan

- [x] Build and load nvmevirt kernel module successfully
- [x] Verify `/dev/nvme0n1` device creation
- [x] Build with kernel driver support (`-DWITH_KDD=ON`)
- [ ] Fix runtime device initialization error (`kv_initialize_device failed 0x13`)
- [ ] Run throughput benchmarks with nvmevirt
- [ ] Run examples with nvmevirt

### Known Issues

- Runtime execution currently fails with error `0x13` (KV_ERR_DEVICE_OPEN)
- Build infrastructure and documentation are complete
- Device initialization needs debugging